### PR TITLE
Fixed Empty Query String Bug #3

### DIFF
--- a/src/crud/delete/delete.php
+++ b/src/crud/delete/delete.php
@@ -5,6 +5,7 @@
 <?php
 if (isset($_GET['id'])) {
     include("../../inc_db_params.php");
+    $ShowTable = TRUE;
 
     /* change db to world db */
     mysqli_select_db($conn, $db_name);
@@ -32,8 +33,14 @@ if (isset($_GET['id'])) {
     mysqli_stmt_close($stmt);
     mysqli_close($conn);
 } else {
-    # TODO without query string causes errors
+    $ShowTable = FALSE;
+    $StudentId = "";
+    $FirstName = "";
+    $LastName = "";
+    $School = "";
+    echo "<h4><br>The URL is invalid. An id parameter must be given.<h4>\n";
 }
+if ($ShowTable) {
 ?>
 
 <table>
@@ -54,6 +61,9 @@ if (isset($_GET['id'])) {
         <td><?php echo $School ?></td>
     </tr>
 </table>
+<?php
+}
+?>
 <br />
 <form action="process_delete.php" method="post">
     <input type="hidden" value="<?php echo $StudentId ?>" name="StudentId" />

--- a/src/crud/delete/process_delete.php
+++ b/src/crud/delete/process_delete.php
@@ -39,8 +39,6 @@ if (isset($_POST['StudentId'])) {
         header('Location: ../list');
         exit;
     }
-} else {
-    # TODO without StudentId value causes errors
 }
 ?>
 

--- a/src/crud/display/display.php
+++ b/src/crud/display/display.php
@@ -5,6 +5,7 @@
 <?php
 if (isset($_GET['id'])) {
     include("../../inc_db_params.php");
+    $ShowTable = TRUE;
 
     /* change db to world db */
     mysqli_select_db($conn, $db_name);
@@ -32,8 +33,14 @@ if (isset($_GET['id'])) {
     
     mysqli_close($conn);
 } else {
-    # TODO without query string causes errors
+    $ShowTable = FALSE;
+    $StudentId = "";
+    $FirstName = "";
+    $LastName = "";
+    $School = "";
+    echo "<h4><br>The URL is invalid. An id parameter must be given.<h4>\n";
 }
+if ($ShowTable) {
 ?>
 
 <table>
@@ -54,7 +61,9 @@ if (isset($_GET['id'])) {
         <td><?php echo $School ?></td>
     </tr>
 </table>
-
+<?php
+}
+?>
 <br />
 <a href="../list" class="btn btn-small btn-primary">&lt;&lt; BACK</a>
 

--- a/src/crud/update/update.php
+++ b/src/crud/update/update.php
@@ -3,6 +3,7 @@
 <?php
 if (isset($_GET['id'])) {
     include("../../inc_db_params.php");
+    $ShowDiv = TRUE;
 
     /* change db to world db */
     mysqli_select_db($conn, $db_name);
@@ -29,8 +30,14 @@ if (isset($_GET['id'])) {
     mysqli_stmt_close($stmt);
     mysqli_close($conn);
 } else {
-    # TODO without query string causes errors
+    $ShowDiv = FALSE;
+    $StudentId = "";
+    $FirstName = "";
+    $LastName = "";
+    $School = "";
+    echo "<h4><br>The URL is invalid. An id parameter must be given.<h4>\n";
 }
+if ($ShowDiv) {
 ?>
 
 <h1>Update</h1>
@@ -71,6 +78,17 @@ if (isset($_GET['id'])) {
         </form>
     </div>
 </div>
+<?php
+}
+?>
+<?php
+if ($ShowDiv == FALSE) {
+?>
+<br>
+<a href="../list" class="btn btn-small btn-primary">&lt;&lt; BACK</a>
+<?php
+}
+?>
 
 <br />
 


### PR DESCRIPTION
Echoed appropriate error messages to the screen when query string was not provided on display, delete, and update so that the page didn't crash.